### PR TITLE
INFL-18507: chore: forward GrowthBook secrets through frontend workflow

### DIFF
--- a/.github/workflows/frontend-s3-managed.yaml
+++ b/.github/workflows/frontend-s3-managed.yaml
@@ -53,6 +53,10 @@ on:
         required: true
       CI_AZURE_DEVOPS_CLIENT_ID:
         required: true
+      CI_GROWTHBOOK_CLIENT_ID:
+        required: false
+      CI_GROWTHBOOK_DECRYPTION_KEY:
+        required: false
 
 permissions:
   id-token: write
@@ -83,6 +87,8 @@ jobs:
           SSO_DOMAINS_ONE: ${{ vars.SSO_DOMAINS_ONE }}
           AZURE_DEVOPS_CLIENT_ID: ${{ secrets.CI_AZURE_DEVOPS_CLIENT_ID }}
           GITHUB_APP_LINK: ${{ vars.CI_GITHUB_APP_LINK }}
+          GROWTHBOOK_CLIENT_ID: ${{ secrets.CI_GROWTHBOOK_CLIENT_ID }}
+          GROWTHBOOK_DECRYPTION_KEY: ${{ secrets.CI_GROWTHBOOK_DECRYPTION_KEY }}
 
       - name: "Setup Node ${{ inputs.node-version }}"
         uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # v3.5.0


### PR DESCRIPTION
## Summary

Forward GrowthBook secrets (`CI_GROWTHBOOK_CLIENT_ID`, `CI_GROWTHBOOK_DECRYPTION_KEY`) through the reusable frontend build workflow so they reach `scripts/set_vars.sh` in consumer repos.

Companion to [infralight/frontend#3529](https://github.com/infralight/frontend/pull/3529), which integrates the GrowthBook React SDK and adds these two values as required env vars in `set_vars.sh`. Without this PR, dev/stg/env1-3/prod-eu CI runs of frontend will fail at the *Edit config.js* step.

## What changed

- Declared `CI_GROWTHBOOK_CLIENT_ID` and `CI_GROWTHBOOK_DECRYPTION_KEY` in the workflow's `secrets:` block (both `required: false`).
- Passed them into the `Edit config.js` step alongside the existing AUTH0/AZURE secrets.

## Why `required: false`

The other caller of this workflow (`infralight/firefly-trust-center`) does not use GrowthBook and won't have these secrets defined. Marking them `required: false` keeps that build green. The frontend repo's `set_vars.sh` will still fail loudly if its caller forgets to pass them — that's the explicit signal during rollout.

## Rollout order

1. Merge **this PR** first (adds support; no behavior change for current callers).
2. Merge [infralight/frontend#3529](https://github.com/infralight/frontend/pull/3529) (uses the support; relies on the secrets actually flowing through).
3. Add `CI_GROWTHBOOK_CLIENT_ID` and `CI_GROWTHBOOK_DECRYPTION_KEY` secrets to each frontend GitHub environment (dev/stg/env1/env2/env3/prod-eu) with the per-env GrowthBook SDK keys.

## Test plan
- [ ] Trigger an `infralight/frontend` CI run after merge — verify `Edit config.js` step exits 0.
- [ ] Trigger an `infralight/firefly-trust-center` CI run — verify it still passes (no GrowthBook secrets required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
