### PR TITLE
INFL-19479: chore: remove npm --legacy-peer-deps from frontend deploy workflow

### DIFF
--- a/.github/workflows/frontend-s3-managed.yaml
+++ b/.github/workflows/frontend-s3-managed.yaml
@@ -120,7 +120,7 @@ jobs:
           echo "K8S_API=https://k8s-api.prod.external.api.infralight.cloud" >> $GITHUB_ENV
 
       - name: Install Dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Run Jest Tests
         if: inputs.run-tests


### PR DESCRIPTION
## Summary
- Drops `--legacy-peer-deps` from the `Install Dependencies` step (`npm ci`) of the reusable `frontend-s3-managed` deploy workflow.
- Follow-up to **infralight/frontend#3917**, which genuinely resolves the four peer-dependency conflicts the flag was masking. The in-repo build/test workflows were updated there; this reusable deploy workflow lives in `infralight/.github`, so it's a separate PR.

## ⚠️ Merge ordering — must land AFTER frontend#3917
`--legacy-peer-deps` is backward-compatible: on a clean (post-#3917) lockfile it's a no-op. The reverse is not — `npm ci` **without** the flag against the current `frontend` main lockfile fails with `ERESOLVE` and breaks the deploy.

- **Do not merge this before #3917.** Merge (or auto-merge) only once #3917 is on `frontend` main.
- Leaving the flag in place until then is harmless.

## Test plan
- [x] Install step validated against #3917's branch: `npm ci` (no flag) on Node 24 → exit 0, no `ERESOLVE`, clean tree.
- [ ] Confirm #3917 is merged to `frontend` main before merging this.
