### PR TITLE
INFL-19653: ci: bump frontend build actions off deprecated Node 20

### DIFF
--- a/.github/workflows/frontend-s3-managed.yaml
+++ b/.github/workflows/frontend-s3-managed.yaml
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Git Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Edit config.js
         run: ./scripts/set_vars.sh
@@ -94,12 +94,12 @@ jobs:
           GROWTHBOOK_DECRYPTION_KEY: ${{ secrets.CI_GROWTHBOOK_DECRYPTION_KEY }}
 
       - name: "Setup Node ${{ inputs.node-version }}"
-        uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # v3.5.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Node Cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         id: npm-cache
         with:
           path: |
@@ -165,7 +165,7 @@ jobs:
           rm -rf /tmp/aws/
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         env:
           environment: ${{ startsWith(inputs.environment, 'env') && 'dev' || inputs.environment }}
         with:


### PR DESCRIPTION
## What kind of change does this PR introduce?
- [x] Code maintenance (CI / reusable-workflow deprecation cleanup)

## Description of the changes

Part of epic **INFL-19646** (Clean up frontend build warnings & deprecations).

The "CI Frontend → Frontend - Build & Deploy" job emits the annotation:

> Node.js 20 is deprecated. Please update the following actions to a version that runs on Node.js 24: actions/cache, actions/checkout, actions/setup-node, aws-actions/configure-aws-credentials

This re-pins those four actions in the reusable workflow `frontend-s3-managed.yaml` (the workflow `ci-frontend.yaml` calls via `call-frontend-workflow` / `trunk-deploy-build`) to versions that run on the **Node.js 24** runtime. Each is bumped to the first major release that targets Node 24 (latest patch in that line), and remains **SHA-pinned with a version comment** per repo convention:

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `93ea575…` # v3.1.0 | `93cb6efe…` # v5.0.1 |
| `actions/setup-node` | `969bd266…` # v3.5.0 | `a0853c24…` # v5.0.0 |
| `actions/cache` | `0057852b…` # v4 | `caa29612…` # v5.1.0 |
| `aws-actions/configure-aws-credentials` | `ff717079…` # v4 | `254c19bd…` # v6.2.1 |

Scope is limited to the single file the task names; no other workflow files are touched. Functional inputs/usage of each action are unchanged — only the pinned ref (and version comment) move.

## Does this PR introduce a breaking change?
No.

## CI-level validation

The reusable workflow cannot be executed from this environment, so validation is static:

```
$ python3 -c "import yaml; yaml.safe_load(open('frontend-s3-managed.yaml'))"
YAML parses OK

$ actionlint frontend-s3-managed.yaml
frontend-s3-managed.yaml:71:28: label "frontend" is unknown ... if it is a custom label
for self-hosted runner, set list of labels in actionlint.yaml config file [runner-label]
```

The only actionlint finding is the **pre-existing** custom self-hosted runner label (`[self-hosted, frontend, …]`) on line 71 — unrelated to this change and present on `master` too. No new lint issues are introduced. The diff is exactly the 4 lines above.

## Still needs human/local validation
- **Trigger an actual `CI Frontend` run** (the `Frontend - Build & Deploy` job runs on the `self-hosted, frontend` runner) to confirm the bumped actions execute green end-to-end. The source job's deprecation annotation said the old actions were already being *force-run on Node.js 24*, which indicates the self-hosted runner is new enough (Actions runner ≥ v2.327.1, required by these Node 24 action versions) — but this should be confirmed on a real run before merge.
- Confirm the version choices are acceptable (first Node-24 major per action). If the team prefers the very latest majors (checkout v7 / setup-node v6 / cache v6), that can be adjusted.

Do not auto-merge — for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhhFGYuXQ7dC2pr1KiBDhu

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhhFGYuXQ7dC2pr1KiBDhu)_