### PR TITLE
INFL-18366 ci: migrate to GitHub ARC prod runner

### DIFF
--- a/.github/workflows/argocd-sync.yaml
+++ b/.github/workflows/argocd-sync.yaml
@@ -63,7 +63,7 @@ jobs:
   argocd:
     environment: ${{ startsWith(inputs.cluster, 'env') && inputs.cluster || inputs.environment }}
     name: "Update image tag and sync changes on cluster."
-    runs-on: [self-hosted, "prod", "arm64"]
+    runs-on: infralight-runner-prod-arc-arm64
     steps:
       - id: string
         uses: ASzc/change-string-case-action@d0603cd0a7dd490be678164909f65c7737470a7f # v6


### PR DESCRIPTION
⚠️ DO NOT MERGE until the prod ARC pools are live — depends on infralight/argocd#3897 being merged + synced + the scale set showing Online. Merging before then makes CI jobs queue forever.

Migrates `runs-on` from the deprecated Summerwind label set to the GitHub ARC scale-set name (ARC scale sets route by name, not labels). Part of INFL-18366.
