### PR TITLE
INFL-18366: migrate CI runners to GitHub ARC

### DIFF
--- a/.github/workflows/argocd-sync.yaml
+++ b/.github/workflows/argocd-sync.yaml
@@ -63,7 +63,7 @@ jobs:
   argocd:
     environment: ${{ startsWith(inputs.cluster, 'env') && inputs.cluster || inputs.environment }}
     name: "Update image tag and sync changes on cluster."
-    runs-on: [self-hosted, "prod", "arm64"]
+    runs-on: infralight-runner-prod-arc-arm64
     steps:
       - id: string
         uses: ASzc/change-string-case-action@d0603cd0a7dd490be678164909f65c7737470a7f # v6

--- a/.github/workflows/cached-golang-ecr-image-managed.yaml
+++ b/.github/workflows/cached-golang-ecr-image-managed.yaml
@@ -136,7 +136,7 @@ on:
 jobs:
   tests:
     name: Run Tests
-    runs-on: [self-hosted, arm64 ,'${{ inputs.environment }}']
+    runs-on: infralight-runner-${{ inputs.environment }}-arc-arm64
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/frontend-s3-managed.yaml
+++ b/.github/workflows/frontend-s3-managed.yaml
@@ -68,7 +68,7 @@ jobs:
   build:
     environment: ${{ inputs.environment }}
     name: "Frontend - Build & Deploy"
-    runs-on: [self-hosted, frontend, "${{ inputs.environment }}"]
+    runs-on: infralight-runner-${{ inputs.environment }}-arc-amd
     timeout-minutes: 30
     steps:
       - name: Git Checkout

--- a/.github/workflows/frontend-s3-managed.yaml
+++ b/.github/workflows/frontend-s3-managed.yaml
@@ -68,7 +68,7 @@ jobs:
   build:
     environment: ${{ inputs.environment }}
     name: "Frontend - Build & Deploy"
-    runs-on: infralight-runner-${{ inputs.environment }}-arc-amd
+    runs-on: infralight-runner-${{ inputs.environment }}-arc-arm64
     timeout-minutes: 30
     steps:
       - name: Git Checkout


### PR DESCRIPTION
REUSABLE WORKFLOWS - HIGH BLAST RADIUS: these run for every caller repo across all envs. argocd-sync -> infralight-runner-prod-arc-arm64. cached-golang-ecr-image-managed -> infralight-runner-<env>-arc-arm64. frontend-s3-managed -> infralight-runner-<env>-arc-amd (NO frontend pool exists; mapped to amd - CONFIRM). Do NOT merge until stag+dev+prod ARC pools are all live and validated, or callers on missing envs will break.

Migrate CI runners from Summerwind label arrays to GitHub ARC scale sets (INFL-18366). Rules: arch-less labels map to the amd pool (agreed default); explicit arm64 kept; automation role maps to the automation pool; env-templated runs-on stays templated across envs. DRAFT: hold until each target env ARC pool is validated (only stag is live today).

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use the latest managed runner labels.
  * Maintained existing synchronization, testing, build, and deployment behavior while improving runner selection across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->