### PR TITLE
INFL-20418: fix: calc-cache-vars go-version input as floor, not fallback

### DIFF
--- a/.github/actions/calc-cache-vars/golang.sh
+++ b/.github/actions/calc-cache-vars/golang.sh
@@ -21,12 +21,15 @@ if [ "$IS_CACHE_MANAGER" == "true" ]; then
     fi
 fi
 
-# Override GO_VERSION from go.mod
+# Resolve GO_VERSION: the installed toolchain must satisfy both the app's
+# go.mod and the workflow's declared go-version (a go.work directive may be
+# newer than the app's go.mod, and GOTOOLCHAIN=local forbids auto-upgrades),
+# so take the higher of the two.
 go_version_extracted=$(extract_app_go_version "$APP_NAME" 2>/dev/null)
 if [ -z "$go_version_extracted" ]; then
     echo "Warning: failed to extract Go version. Falling back to GO_VERSION: $GO_VERSION" >&2
 else
-    GO_VERSION="$go_version_extracted"
+    GO_VERSION=$(printf '%s\n%s\n' "$GO_VERSION" "$go_version_extracted" | sort -V | tail -1)
 fi
 echo $GO_VERSION
 


### PR DESCRIPTION
## Jira
INFL-20418

## Type
- [x] Bug fix (CI/CD — org-wide shared action)

## What broke
Every iac-ci service deploy fails since the go.work `go 1.26.5` bump (iac-ci#1082):
```
go: go.work requires go >= 1.26.5 (running go 1.26.1; GOTOOLCHAIN=local)
```

`calc-cache-vars` extracts the Go version from the **app's go.mod** and silently **discards the workflow's `go-version` input** — run 29567... (job 87869302927) received `go-version: 1.26.5` and still installed 1.26.1 from `components/orchestrator-api/go.mod`. Under `GOTOOLCHAIN=local` on the self-hosted runners there's no auto-upgrade, so the workspace build dies.

## Fix
Treat the input as a **floor**: install `max(go-version input, go.mod version)` — the toolchain must satisfy both the app's go.mod and the workspace/pin. A newer go.mod still wins over a stale pin (original intent preserved); a newer declared pin no longer gets silently downgraded.

## Blast radius / verification
- Org-wide action, but behavior only changes when a workflow's declared `go-version` is **newer** than the app's go.mod — today that silently installs the older one; after this it installs the declared one. A newer toolchain always satisfies an older `go` directive, so this direction is safe.
- Cache keys use the trimmed minor (`golang-v1.26-...`) — unchanged for same-minor bumps.
- Tested the script against iac-ci locally: input 1.26.5 + go.mod 1.26.1 → `1.26.5` (fixes deploys); input 1.20 + go.mod 1.26.1 → `1.26.1` (go.mod still wins); extraction-failure fallback path untouched.

Pairs with infralight/infrastructure#1702 (bumps iac-ci's declared `go_version` pins to 1.26.5). Together they fix the deploys with **zero changes in iac-ci** — component go.mods stay at `go 1.26.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Go version detection to select the newest version declared by the workflow or application configuration.
  * Prevented valid workflow-defined Go versions from being unnecessarily downgraded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->