### PR TITLE
INFL-20419: gate public-ECR prod releases on Trivy CVE scan

### DIFF
--- a/.github/workflows/cached-golang-ecr-image-managed.yaml
+++ b/.github/workflows/cached-golang-ecr-image-managed.yaml
@@ -343,6 +343,26 @@ jobs:
           S3_BUCKET: firefly-${{ contains(fromJSON('["prod", "stag"]'), inputs.environment) && inputs.environment || inputs.cluster }}-trivy-scans
         run: aws s3 cp "./$TRIVY_RESULT" "s3://$S3_BUCKET/$TRIVY_RESULT"
 
+      # Gating dependency scan (INFL-20419): runs on releases that push to the
+      # PUBLIC ECR (public.ecr.aws/firefly) on prod, before the ECR login/push
+      # steps, and fails the build on CRITICAL/HIGH CVEs. Scoped to public-ECR
+      # prod so private-ECR consumers of this reusable workflow are unaffected.
+      # fs/dependency scan (not image): the multi-arch prod path builds+pushes
+      # via buildx in one step with no local image to scan, and this catches the
+      # Go-dependency CVE class (e.g. x/net CVE-2026-39821) shipped in binaries.
+      - name: Trivy dependency scan (gating)
+        if: ${{ inputs.ecr-public-registry != '' && inputs.environment == 'prod' }}
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # master (v0.69.2)
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          version: 'v0.69.2'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'library'
+          severity: 'CRITICAL,HIGH'
+
       - name: AWS ECR Login
         if: inputs.ecr-public-registry == '' || inputs.environment != 'prod'
         uses: aws-actions/amazon-ecr-login@c962da2960ed15f492addc26fffa274485265950 # v2


### PR DESCRIPTION
## Jira
INFL-20419

## Change type
Feature (CI security gate)

## What changed
Adds a gating Trivy `fs`/dependency scan to `cached-golang-ecr-image-managed.yaml`, before the ECR login/push steps:

```yaml
- name: Trivy dependency scan (gating)
  if: ${{ inputs.ecr-public-registry != '' && inputs.environment == 'prod' }}
  uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.69.2
  with:
    scan-type: 'fs'
    scan-ref: '.'
    version: 'v0.69.2'
    format: 'table'
    exit-code: '1'
    ignore-unfixed: true
    vuln-type: 'library'
    severity: 'CRITICAL,HIGH'
```

## Why
Per INFL-20419: builds that publish to the **public** registry `public.ecr.aws/firefly` had no vulnerability gate. Ramp's scanner flagged CVE-2026-39821 (`x/net` idna, CVSS 9.6) in the shipped `fireflyci` binary. This gates such releases before the push.

## Scope / blast radius
- Runs **only** when `ecr-public-registry != '' && environment == 'prod'` — i.e. public-ECR prod releases. Private-ECR consumers of this reusable workflow are **unaffected**.
- Covers `ci-runner-worker` and `firefly-runners-env3` (both public-ECR) — the ci-runner-worker half of INFL-20419. The firefly-ci CLI half is handled separately in the iac-ci-cli GoReleaser pipeline (infrastructure PR #1740).

## Why `fs`, not an image scan
The multi-arch prod path (`IS_MULTI_ARCH_PROD == true`) builds **and** pushes via a single `docker buildx --push` step — there's no local image to scan before push, and a multi-arch manifest can't be `--load`ed. An `fs` scan reads `go.sum` and catches the Go-dependency CVE class that caused the incident, and truly runs pre-push. `ignore-unfixed: true` avoids blocking on CVEs with no available fix.

## Note
Added to the `cached-` variant used by the Go release path. No change to `modules/github/ci` or consuming repos was needed — the gate keys off existing inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automated dependency vulnerability scanning for production public container image builds.
  * Builds now fail when high- or critical-severity, fixable library vulnerabilities are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->