### PR TITLE
INFL-18366: route dev/stag ECR build to new ARC runners

### DIFF
--- a/.github/workflows/cached-golang-ecr-image-managed.yaml
+++ b/.github/workflows/cached-golang-ecr-image-managed.yaml
@@ -176,8 +176,8 @@ jobs:
   build-push-ecr:
     name: "Build & Push ECR Docker Image "
     environment: ${{ inputs.environment }}
-    # prod stays on the legacy runner; dev/stag use the new ARC arm64 pool
-    runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-24.04-amd' || fromJSON(format('["self-hosted", "arm64", "{0}"]', inputs.environment)) }}
+    # prod stays on the legacy runner; dev/stag use the new ARC amd pool
+    runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-24.04-amd' || fromJSON(format('["self-hosted", "X64", "{0}"]', inputs.environment)) }}
     outputs:
       image-tag: ${{ steps.vars.outputs.image-tag }}
     env:

--- a/.github/workflows/cached-golang-ecr-image-managed.yaml
+++ b/.github/workflows/cached-golang-ecr-image-managed.yaml
@@ -176,8 +176,8 @@ jobs:
   build-push-ecr:
     name: "Build & Push ECR Docker Image "
     environment: ${{ inputs.environment }}
-    # prod stays on the legacy runner; dev/stag use the new ARC amd pool
-    runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-24.04-amd' || fromJSON(format('["self-hosted", "X64", "{0}"]', inputs.environment)) }}
+    # prod stays on the legacy runner; dev/stag build natively on the new ARC arm64 pool
+    runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-24.04-amd' || fromJSON(format('["self-hosted", "arm64", "{0}"]', inputs.environment)) }}
     outputs:
       image-tag: ${{ steps.vars.outputs.image-tag }}
     env:

--- a/.github/workflows/cached-golang-ecr-image-managed.yaml
+++ b/.github/workflows/cached-golang-ecr-image-managed.yaml
@@ -176,8 +176,8 @@ jobs:
   build-push-ecr:
     name: "Build & Push ECR Docker Image "
     environment: ${{ inputs.environment }}
-    # prod stays on the legacy runner; dev/stag use the new ARC amd pool
-    runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-24.04-amd' || fromJSON(format('["self-hosted", "X64", "{0}"]', inputs.environment)) }}
+    # prod stays on the legacy runner; dev/stag use the new ARC arm64 pool
+    runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-24.04-amd' || fromJSON(format('["self-hosted", "arm64", "{0}"]', inputs.environment)) }}
     outputs:
       image-tag: ${{ steps.vars.outputs.image-tag }}
     env:

--- a/.github/workflows/cached-golang-ecr-image-managed.yaml
+++ b/.github/workflows/cached-golang-ecr-image-managed.yaml
@@ -176,7 +176,8 @@ jobs:
   build-push-ecr:
     name: "Build & Push ECR Docker Image "
     environment: ${{ inputs.environment }}
-    runs-on: 'ubuntu-24.04-amd'
+    # prod stays on the legacy runner; dev/stag use the new ARC amd pool
+    runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-24.04-amd' || fromJSON(format('["self-hosted", "X64", "{0}"]', inputs.environment)) }}
     outputs:
       image-tag: ${{ steps.vars.outputs.image-tag }}
     env:

--- a/.github/workflows/cached-golang-ecr-image-managed.yaml
+++ b/.github/workflows/cached-golang-ecr-image-managed.yaml
@@ -296,6 +296,13 @@ jobs:
         with:
           platforms: "arm64"
 
+      - name: Set up Docker Buildx
+        if: ${{ inputs.arm64 }}
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          # docker driver stores the built image in the engine so the later tag/push step can find it
+          driver: docker
+
       - name: Go Build (ARM64)
         if: ${{ inputs.arm64 }}
         env:


### PR DESCRIPTION
## INFL-18366

Part of the self-hosted GitHub runners migration (legacy summerwind ARC → GitHub ARC).

### Change type
Code maintenance

### What
Routes the reusable `build-push-ecr` job to the new ARC runners for **dev** and **stag**, while keeping **prod** on the legacy `ubuntu-24.04-amd` runner:

```yaml
runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-24.04-amd' || fromJSON(format('["self-hosted", "amd", "{0}"]', inputs.environment)) }}
```

### Why
`build-push-ecr` was pinned to the legacy summerwind runner. This gates runner selection by environment so dev/stag exercise the new ARC amd pool while prod stays on the proven legacy runner until it is migrated separately. (The `tests` job already runs on the new ARC runners.)

### Testing
Branch-pin one dev service's caller to `…@INFL-18366-build-ecr-dev-stag-runners` and dispatch (all envs — prod safely stays on `ubuntu-24.04-amd`). Confirm the dev/stag `build-push-ecr` jobs land on `infralight-runner-{dev,stag}-arc-amd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build workflows to select optimized AMD runners based on the deployment environment.
  * Production builds use Ubuntu 24.04 AMD runners, while other environments use their designated self-hosted runners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->