### PR TITLE
[TEMPORARY] ci: run Go tests on ubuntu-24.04-amd — arm64 runners can't host amd64-only test images

### DIFF
--- a/.github/workflows/cached-golang-ecr-image-managed.yaml
+++ b/.github/workflows/cached-golang-ecr-image-managed.yaml
@@ -136,7 +136,7 @@ on:
 jobs:
   tests:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-amd
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/cached-golang-ecr-image-managed.yaml
+++ b/.github/workflows/cached-golang-ecr-image-managed.yaml
@@ -136,7 +136,7 @@ on:
 jobs:
   tests:
     name: Run Tests
-    runs-on: [self-hosted, arm64 ,'${{ inputs.environment }}']
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## TEMPORARY — please revert or replace once the arm64 runners can host these tests

Moves **only** the `tests` job of `cached-golang-ecr-image-managed.yaml` off the self-hosted arm64 runners and onto `ubuntu-24.04-amd` — the same amd64 label `build-push-ecr` already uses. The Docker build job and all `inputs.arm64` build logic are untouched, so shipped images stay arm64.

```diff
   tests:
     name: Run Tests
-    runs-on: [self-hosted, arm64 ,'${{ inputs.environment }}']
+    runs-on: ubuntu-24.04-amd
```

### The incident

Every `CI GCP-TEMPORAL-WORKERS Deploy` run on `infralight/flywheel-provider-gcp` has been failing at `make test`, blocking deploys. Example: [run 31019421718](https://github.com/infralight/flywheel-provider-gcp/actions/runs/31019421718/job/92351962546).

- **Symptom** — one package, `applications/consumer/temporal/activity`, exits with a bare `exit status 1` after ~120s. No `--- FAIL` lines and no error message, because the failure is in `TestMain`'s container setup, which `os.Exit(1)`s after logging (and non-verbose `go test` surfaces nothing useful). All 18 other packages pass.

- **Cause** — that package spins up 7 testcontainers, one of which is the GCP Pub/Sub emulator image `gcr.io/google.com/cloudsdktool/cloud-sdk:542.0.0-emulators`. That image is published as a **single-arch amd64 manifest** — there is no arm64 variant. On the arm64 test runners it cannot exec, so the wait strategy times out and setup aborts.

- **Why it works on developer machines** — Docker Desktop on Apple Silicon emulates amd64 (Rosetta/QEMU), so the emulator container runs locally. Verified: the package passes on an M-series Mac (`ok ... 130.139s`) while failing on the arm64 CI runners.

### Why this fix is temporary

It papers over an arm64 runner capability gap rather than fixing it, and it splits the test job's architecture from the runtime architecture we actually ship — so arm-specific test failures would no longer be caught in CI. Note the job also drops the `${{ inputs.environment }}` label; these tests only need Docker plus `GLOBAL_PAT` for private modules, so that's fine today, but any repo whose `make test` reaches an env-specific internal endpoint would break.

Longer-term options, in rough order of preference:

1. Add QEMU/binfmt (`docker/setup-qemu-action`) to the self-hosted arm64 runners so amd64 test images run there, and revert this.
2. Replace the Pub/Sub emulator with a multi-arch image, or start the emulator via the `gcloud` CLI instead of the `cloud-sdk` image.
3. Gate the testcontainers-based integration tests behind a build tag so the deploy pipeline doesn't run them at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)