### PR TITLE
INFL-18366: run node ECR and frontend S3 workflows on self-hosted ARC runners

### DIFF
--- a/.github/workflows/cached-frontend-s3-managed.yaml
+++ b/.github/workflows/cached-frontend-s3-managed.yaml
@@ -58,8 +58,8 @@ jobs:
   build:
     environment: ${{ inputs.environment }}
     name: "Frontend - Build & Deploy"
-    # runs-on: [self-hosted, frontend, "${{ inputs.environment }}"]
-    runs-on: ubuntu-latest
+    # prod stays on the GitHub-hosted runner; dev/stag build on the self-hosted frontend pool
+    runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-latest' || fromJSON(format('["self-hosted", "frontend", "{0}"]', inputs.environment)) }}
     env:
       AWS_REGION: ${{ inputs.aws-region }}
     steps:

--- a/.github/workflows/cached-frontend-s3-managed.yaml
+++ b/.github/workflows/cached-frontend-s3-managed.yaml
@@ -58,8 +58,8 @@ jobs:
   build:
     environment: ${{ inputs.environment }}
     name: "Frontend - Build & Deploy"
-    # prod stays on the GitHub-hosted runner; dev/stag build on the self-hosted frontend pool
-    runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-latest' || fromJSON(format('["self-hosted", "frontend", "{0}"]', inputs.environment)) }}
+    # runs-on: [self-hosted, frontend, "${{ inputs.environment }}"]
+    runs-on: ubuntu-latest
     env:
       AWS_REGION: ${{ inputs.aws-region }}
     steps:

--- a/.github/workflows/cached-frontend-s3-managed.yaml
+++ b/.github/workflows/cached-frontend-s3-managed.yaml
@@ -58,7 +58,8 @@ jobs:
   build:
     environment: ${{ inputs.environment }}
     name: "Frontend - Build & Deploy"
-    runs-on: [self-hosted, frontend, "${{ inputs.environment }}"]
+    # prod stays on the GitHub-hosted runner; dev/stag build on the self-hosted frontend pool
+    runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-latest' || fromJSON(format('["self-hosted", "frontend", "{0}"]', inputs.environment)) }}
     env:
       AWS_REGION: ${{ inputs.aws-region }}
     steps:

--- a/.github/workflows/cached-frontend-s3-managed.yaml
+++ b/.github/workflows/cached-frontend-s3-managed.yaml
@@ -58,8 +58,7 @@ jobs:
   build:
     environment: ${{ inputs.environment }}
     name: "Frontend - Build & Deploy"
-    # runs-on: [self-hosted, frontend, "${{ inputs.environment }}"]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, frontend, "${{ inputs.environment }}"]
     env:
       AWS_REGION: ${{ inputs.aws-region }}
     steps:

--- a/.github/workflows/cached-frontend-s3-managed.yaml
+++ b/.github/workflows/cached-frontend-s3-managed.yaml
@@ -58,7 +58,6 @@ jobs:
   build:
     environment: ${{ inputs.environment }}
     name: "Frontend - Build & Deploy"
-    # prod stays on the GitHub-hosted runner; dev/stag build on the self-hosted frontend pool
     runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-latest' || fromJSON(format('["self-hosted", "frontend", "{0}"]', inputs.environment)) }}
     env:
       AWS_REGION: ${{ inputs.aws-region }}
@@ -93,7 +92,11 @@ jobs:
 
       - name: Install AWS Cli
         run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+          case "$(uname -m)" in
+            aarch64|arm64) ARCH=aarch64 ;;
+            *)             ARCH=x86_64 ;;
+          esac
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-$ARCH.zip" -o /tmp/awscliv2.zip
           unzip -q /tmp/awscliv2.zip -d /tmp
           rm /tmp/awscliv2.zip
           sudo /tmp/aws/install --update

--- a/.github/workflows/cached-node-ecr-image-managed.yaml
+++ b/.github/workflows/cached-node-ecr-image-managed.yaml
@@ -80,7 +80,7 @@ permissions:
 jobs:
   tests:
     if: inputs.run-tests == true
-    runs-on: 'ubuntu-latest'
+    runs-on: [self-hosted, arm64, '${{ inputs.environment }}']
     name: "Run Tests"
     steps:
       - run: |
@@ -89,7 +89,7 @@ jobs:
   build:
     environment: ${{ inputs.environment }}
     name: "Build & Push ECR Docker Image "
-    runs-on: 'ubuntu-latest'
+    runs-on: [self-hosted, arm64, '${{ inputs.environment }}']
     env:
       HAVE_GLOBAL_PAT: ${{ secrets.GLOBAL_PAT != '' }}
       HAVE_RUN_CMD: ${{ inputs.run != '' }}

--- a/.github/workflows/cached-node-ecr-image-managed.yaml
+++ b/.github/workflows/cached-node-ecr-image-managed.yaml
@@ -111,6 +111,15 @@ jobs:
         with:
           platforms: "arm64"
 
+      # The self-hosted runner image ships docker without the buildx plugin, so
+      # `docker buildx build` fails with "unknown flag: --platform". Both the
+      # AMD64 and ARM64 paths shell out to buildx, so this is not gated on arm64.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          # docker driver stores the built image in the engine so the later tag/push step can find it
+          driver: docker
+
       - name: Configure Git for Private Modules
         if: ${{ env.HAVE_GLOBAL_PAT == 'true' }}
         run: git config --global url."https://${{ secrets.GLOBAL_PAT }}:x-oauth-basic@github.com".insteadOf "https://github.com"

--- a/.github/workflows/cached-node-ecr-image-managed.yaml
+++ b/.github/workflows/cached-node-ecr-image-managed.yaml
@@ -111,13 +111,9 @@ jobs:
         with:
           platforms: "arm64"
 
-      # The self-hosted runner image ships docker without the buildx plugin, so
-      # `docker buildx build` fails with "unknown flag: --platform". Both the
-      # AMD64 and ARM64 paths shell out to buildx, so this is not gated on arm64.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
-          # docker driver stores the built image in the engine so the later tag/push step can find it
           driver: docker
 
       - name: Configure Git for Private Modules

--- a/.github/workflows/frontend-s3-managed.yaml
+++ b/.github/workflows/frontend-s3-managed.yaml
@@ -158,7 +158,11 @@ jobs:
       - name: Install AWS Cli
         if: ${{ !contains(runner.name, 'GitHub Actions') }}
         run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+          case "$(uname -m)" in
+            aarch64|arm64) ARCH=aarch64 ;;
+            *)             ARCH=x86_64 ;;
+          esac
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-$ARCH.zip" -o /tmp/awscliv2.zip
           unzip -q /tmp/awscliv2.zip -d /tmp
           rm /tmp/awscliv2.zip
           sudo /tmp/aws/install --update

--- a/.github/workflows/node-ecr-image-managed.yaml
+++ b/.github/workflows/node-ecr-image-managed.yaml
@@ -80,7 +80,7 @@ permissions:
 jobs:
   tests:
     if: inputs.run-tests == true
-    runs-on: 'ubuntu-latest'
+    runs-on: [self-hosted, arm64, '${{ inputs.environment }}']
     name: "Run Tests"
     steps:
       - run: |
@@ -89,7 +89,7 @@ jobs:
   build:
     environment: ${{ inputs.environment }}
     name: "Build & Push ECR Docker Image "
-    runs-on: 'ubuntu-latest'
+    runs-on: [self-hosted, arm64, '${{ inputs.environment }}']
     env:
       HAVE_GLOBAL_PAT: ${{ secrets.GLOBAL_PAT != '' }}
       HAVE_RUN_CMD: ${{ inputs.run != '' }}

--- a/.github/workflows/node-ecr-image-managed.yaml
+++ b/.github/workflows/node-ecr-image-managed.yaml
@@ -102,6 +102,15 @@ jobs:
         if: ${{ env.HAVE_GLOBAL_PAT == 'true' }}
         run: git config --global url."https://${{ secrets.GLOBAL_PAT }}:x-oauth-basic@github.com".insteadOf "https://github.com"
 
+      # The self-hosted runner image ships docker without the buildx plugin, so
+      # `docker buildx build` fails with "unknown flag: --platform". Both the
+      # AMD64 and ARM64 paths shell out to buildx, so this is not gated on arm64.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          # docker driver stores the built image in the engine so the later tag/push step can find it
+          driver: docker
+
       - name: Build Docker Image
         id: build
         if: ${{ !inputs.arm64 && env.HAVE_RUN_CMD == 'false' }}

--- a/.github/workflows/node-ecr-image-managed.yaml
+++ b/.github/workflows/node-ecr-image-managed.yaml
@@ -102,13 +102,9 @@ jobs:
         if: ${{ env.HAVE_GLOBAL_PAT == 'true' }}
         run: git config --global url."https://${{ secrets.GLOBAL_PAT }}:x-oauth-basic@github.com".insteadOf "https://github.com"
 
-      # The self-hosted runner image ships docker without the buildx plugin, so
-      # `docker buildx build` fails with "unknown flag: --platform". Both the
-      # AMD64 and ARM64 paths shell out to buildx, so this is not gated on arm64.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
-          # docker driver stores the built image in the engine so the later tag/push step can find it
           driver: docker
 
       - name: Build Docker Image


### PR DESCRIPTION
## Jira Ticket
[INFL-18366](https://infralight1.atlassian.net/browse/INFL-18366) — Migrate from Summerwind ARC to official GitHub ARC (actions-runner-controller v2)

## Change Type
- [x] Code maintenance

## Description
Moves the reusable Node ECR workflows onto the self-hosted ARC pools, and makes the frontend S3 workflows safe to run on arm64.

| Workflow | Change |
|---|---|
| `node-ecr-image-managed.yaml` | `tests` + `build` → `[self-hosted, arm64, <env>]`; add buildx |
| `cached-node-ecr-image-managed.yaml` | same |
| `cached-frontend-s3-managed.yaml` | dev/stag → self-hosted `frontend` pool, prod stays `ubuntu-latest`; arch-aware AWS CLI |
| `frontend-s3-managed.yaml` | arch-aware AWS CLI only (`runs-on` unchanged) |

### 1. Node ECR → self-hosted, all environments
No prod carve-out, unlike the golang workflow:

```yaml
runs-on: [self-hosted, arm64, '${{ inputs.environment }}']
```

### 2. Docker buildx
The ARC runner image ships docker without the buildx plugin, so `docker buildx build` failed with `unknown flag: --platform` (exit 125). Added ungated — both the AMD64 and ARM64 paths shell out to buildx, unlike golang where only the arm64 path is self-hosted. `driver: docker` so the image lands in the engine for the later `docker tag` / `docker push`.

### 3. Frontend S3 — dev/stag only
```yaml
runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-latest' || fromJSON(format('["self-hosted", "frontend", "{0}"]', inputs.environment)) }}
```

### 4. AWS CLI installer by architecture
Both frontend workflows hardcoded `awscli-exe-linux-x86_64.zip`. Required before infralight/argocd#4192 adds `frontend` to the prod arm64 pool, which pins `karpenter.firefly.ai/arch=arm64`. No-op on amd.

## Validation
- `terraform-state-reducer` — `Build & Push ECR Docker Image` passed in 30s on a self-hosted runner after the buildx fix.
- Not yet validated: `aegis`, the `arm64: false` path, and the frontend workflows on a true arm64 node.

## Related
- infralight/infrastructure#1767 — pins `aegis` + `terraform-state-reducer` (merged)
- infralight/infrastructure#1768 — pins `frontend`
- infralight/argocd#4192 — `frontend` label on prod arm64 pool (**merge this PR first**)

## Risks
1. **Blast radius.** `node-ecr-image-managed.yaml` is what the terraform CI generator emits for every Node repo — ~21 apps / 15 repos track `@master`. Two callers won't pick this up: `gofireflyio/firefly-mcp` (SHA-pinned) and `infralight/demo-backstage` (`@backstage`).
2. **`cached-frontend-s3-managed.yaml` has one caller — `infralight/firefly-trust-center` — which passes `environment: product`.** No scale set advertises a `product` label, so that repo's frontend deploy will queue indefinitely once this merges. Its `ci.tf` in infrastructure is fully commented out, so it can't be pinned or tested from terraform. **Needs resolving before merge.**
3. `fcit-ui` is the last unverified `arm64: false` caller.


[INFL-18366]: https://infralight1.atlassian.net/browse/INFL-18366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ