### PR TITLE
INFL-18366: drop redundant Set up Docker Buildx step from golang workflow

### DIFF
--- a/.github/workflows/cached-golang-ecr-image-managed.yaml
+++ b/.github/workflows/cached-golang-ecr-image-managed.yaml
@@ -296,13 +296,6 @@ jobs:
         with:
           platforms: "arm64"
 
-      - name: Set up Docker Buildx
-        if: ${{ inputs.arm64 }}
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-        with:
-          # docker driver stores the built image in the engine so the later tag/push step can find it
-          driver: docker
-
       - name: Go Build (ARM64)
         if: ${{ inputs.arm64 }}
         env:


### PR DESCRIPTION
## Jira
INFL-18366 — Migrate from Summerwind ARC to official GitHub ARC (actions-runner-controller v2)

## Change type
Code maintenance

## Description
Removes the `Set up Docker Buildx` (`setup-buildx-action`) step from `cached-golang-ecr-image-managed.yaml`. The self-hosted arm64 runner image (`ubuntu-24.04-firefly`) now ships a working buildx builder, so the setup step is redundant for ARM64 builds. QEMU setup and the multi-arch buildx logic are left intact.

## Validation
Verified via terraform-planner CI on the dev/stag arm64 self-hosted runners (firefly image). Prod runners moved to the firefly image in argocd #4216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the container image build workflow by removing the ARM64-specific build setup.
  * Retained existing emulation support for other build requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->