### PR TITLE
INFL-18366: drop redundant Set up Docker Buildx step from node workflows

### DIFF
--- a/.github/workflows/cached-node-ecr-image-managed.yaml
+++ b/.github/workflows/cached-node-ecr-image-managed.yaml
@@ -111,11 +111,6 @@ jobs:
         with:
           platforms: "arm64"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-        with:
-          driver: docker
-
       - name: Configure Git for Private Modules
         if: ${{ env.HAVE_GLOBAL_PAT == 'true' }}
         run: git config --global url."https://${{ secrets.GLOBAL_PAT }}:x-oauth-basic@github.com".insteadOf "https://github.com"

--- a/.github/workflows/node-ecr-image-managed.yaml
+++ b/.github/workflows/node-ecr-image-managed.yaml
@@ -102,11 +102,6 @@ jobs:
         if: ${{ env.HAVE_GLOBAL_PAT == 'true' }}
         run: git config --global url."https://${{ secrets.GLOBAL_PAT }}:x-oauth-basic@github.com".insteadOf "https://github.com"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-        with:
-          driver: docker
-
       - name: Build Docker Image
         id: build
         if: ${{ !inputs.arm64 && env.HAVE_RUN_CMD == 'false' }}


### PR DESCRIPTION
## Jira
INFL-18366 — Migrate from Summerwind ARC to official GitHub ARC (actions-runner-controller v2)

## Change type
Code maintenance

## Description
Removes the `Set up Docker Buildx` (`setup-buildx-action`) step from both node reusable workflows:
- `cached-node-ecr-image-managed.yaml`
- `node-ecr-image-managed.yaml`

The self-hosted arm64 runner image (`ubuntu-24.04-firefly`) ships a working buildx builder, so the setup step is redundant. QEMU setup is left intact.

## Validation
Verified via app-server CI on the dev arm64 self-hosted runner (firefly image). Node builds run on `[self-hosted, arm64, <env>]` for all envs; prod runners were moved to the firefly image first (argocd #4216) so prod builds retain buildx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined container image build workflows by removing redundant build configuration steps.
  * Docker image builds continue using the workflow’s default build settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->