### PR TITLE
INFL-18366: run prod golang+frontend builds on self-hosted runners

### DIFF
--- a/.github/workflows/cached-frontend-s3-managed.yaml
+++ b/.github/workflows/cached-frontend-s3-managed.yaml
@@ -58,7 +58,7 @@ jobs:
   build:
     environment: ${{ inputs.environment }}
     name: "Frontend - Build & Deploy"
-    runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-latest' || fromJSON(format('["self-hosted", "frontend", "{0}"]', inputs.environment)) }}
+    runs-on: [self-hosted, frontend, '${{ inputs.environment }}']
     env:
       AWS_REGION: ${{ inputs.aws-region }}
     steps:

--- a/.github/workflows/cached-golang-ecr-image-managed.yaml
+++ b/.github/workflows/cached-golang-ecr-image-managed.yaml
@@ -176,8 +176,7 @@ jobs:
   build-push-ecr:
     name: "Build & Push ECR Docker Image "
     environment: ${{ inputs.environment }}
-    # prod stays on the legacy runner; dev/stag build natively on the new ARC arm64 pool
-    runs-on: ${{ inputs.environment == 'prod' && 'ubuntu-24.04-amd' || fromJSON(format('["self-hosted", "arm64", "{0}"]', inputs.environment)) }}
+    runs-on: [self-hosted, arm64, '${{ inputs.environment }}']
     outputs:
       image-tag: ${{ steps.vars.outputs.image-tag }}
     env:


### PR DESCRIPTION
## Jira
INFL-18366 — Migrate from Summerwind ARC to official GitHub ARC (actions-runner-controller v2)

## Change type
Code maintenance

## Description
The prod runner pools are now on the `ubuntu-24.04-firefly` image (buildx preinstalled, argocd #4216). This drops the prod→GitHub-hosted special-case in the two reusable workflows that were self-hosted for dev/stag only, so prod builds on the self-hosted pool like every other env:

- **golang** `Build & Push` — prod now `[self-hosted, arm64, prod]` (was `ubuntu-24.04-amd`)
- **frontend** `Build & Deploy` — prod now `[self-hosted, frontend, prod]` (was `ubuntu-latest`)

The other jobs (golang Run Tests, node build/test) were already unconditionally self-hosted arm64.

## ⚠️ Reviewer note — architecture change for prod golang
This moves prod golang builds from **amd64** (GitHub-hosted `ubuntu-24.04-amd`) to **arm64** (self-hosted prod pool). Prod golang images will now be built for **arm64**. Confirm prod workloads run on arm64 nodes before merging. Frontend is an S3 static build (arch-agnostic). Multi-arch prod builds still use buildx+QEMU on the runner.

## Rollout
These workflows are referenced `@master`, so merging affects prod builds on the next run. Prereq (prod runners on firefly image) is already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)