### PR TITLE
INFL-18366: map 'product' frontend env to 'prod' runner label

### DIFF
--- a/.github/workflows/cached-frontend-s3-managed.yaml
+++ b/.github/workflows/cached-frontend-s3-managed.yaml
@@ -58,7 +58,8 @@ jobs:
   build:
     environment: ${{ inputs.environment }}
     name: "Frontend - Build & Deploy"
-    runs-on: [self-hosted, frontend, '${{ inputs.environment }}']
+    # 'product' environment maps to the 'prod' runner label
+    runs-on: ${{ inputs.environment == 'product' && fromJSON('["self-hosted", "frontend", "prod"]') || fromJSON(format('["self-hosted", "frontend", "{0}"]', inputs.environment)) }}
     env:
       AWS_REGION: ${{ inputs.aws-region }}
     steps:


### PR DESCRIPTION
## Description

The reusable frontend build workflow (`cached-frontend-s3-managed.yaml`) builds `runs-on` from `inputs.environment`, but there is no self-hosted runner labeled `product`. When callers pass `product`, the job can't be scheduled.

This maps the `product` environment input to the existing `prod` runner label so those builds get scheduled on the prod self-hosted pool. All other environment values (`dev`, `stag`, etc.) are unchanged.

```yaml
runs-on: ${{ inputs.environment == 'product' && fromJSON('["self-hosted", "frontend", "prod"]') || fromJSON(format('["self-hosted", "frontend", "{0}"]', inputs.environment)) }}
```

Only runner scheduling is affected; the `environment:` key, AWS role, and Slack messages still use the raw `inputs.environment` value.

## Change type

- Bug fix

## Jira

INFL-18366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow runner selection for the production environment.
  * Preserved environment-specific runner selection for other deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->