### PR TITLE
INFL-18366: map 'product' go/node env to 'prod' runner label

### DIFF
--- a/.github/workflows/cached-golang-ecr-image-managed.yaml
+++ b/.github/workflows/cached-golang-ecr-image-managed.yaml
@@ -136,7 +136,8 @@ on:
 jobs:
   tests:
     name: Run Tests
-    runs-on: [self-hosted, arm64 ,'${{ inputs.environment }}']
+    # 'product' environment maps to the 'prod' runner label
+    runs-on: ${{ inputs.environment == 'product' && fromJSON('["self-hosted", "arm64", "prod"]') || fromJSON(format('["self-hosted", "arm64", "{0}"]', inputs.environment)) }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -176,7 +177,8 @@ jobs:
   build-push-ecr:
     name: "Build & Push ECR Docker Image "
     environment: ${{ inputs.environment }}
-    runs-on: [self-hosted, arm64, '${{ inputs.environment }}']
+    # 'product' environment maps to the 'prod' runner label
+    runs-on: ${{ inputs.environment == 'product' && fromJSON('["self-hosted", "arm64", "prod"]') || fromJSON(format('["self-hosted", "arm64", "{0}"]', inputs.environment)) }}
     outputs:
       image-tag: ${{ steps.vars.outputs.image-tag }}
     env:

--- a/.github/workflows/cached-node-ecr-image-managed.yaml
+++ b/.github/workflows/cached-node-ecr-image-managed.yaml
@@ -80,7 +80,8 @@ permissions:
 jobs:
   tests:
     if: inputs.run-tests == true
-    runs-on: [self-hosted, arm64, '${{ inputs.environment }}']
+    # 'product' environment maps to the 'prod' runner label
+    runs-on: ${{ inputs.environment == 'product' && fromJSON('["self-hosted", "arm64", "prod"]') || fromJSON(format('["self-hosted", "arm64", "{0}"]', inputs.environment)) }}
     name: "Run Tests"
     steps:
       - run: |
@@ -89,7 +90,8 @@ jobs:
   build:
     environment: ${{ inputs.environment }}
     name: "Build & Push ECR Docker Image "
-    runs-on: [self-hosted, arm64, '${{ inputs.environment }}']
+    # 'product' environment maps to the 'prod' runner label
+    runs-on: ${{ inputs.environment == 'product' && fromJSON('["self-hosted", "arm64", "prod"]') || fromJSON(format('["self-hosted", "arm64", "{0}"]', inputs.environment)) }}
     env:
       HAVE_GLOBAL_PAT: ${{ secrets.GLOBAL_PAT != '' }}
       HAVE_RUN_CMD: ${{ inputs.run != '' }}

--- a/.github/workflows/node-ecr-image-managed.yaml
+++ b/.github/workflows/node-ecr-image-managed.yaml
@@ -80,7 +80,8 @@ permissions:
 jobs:
   tests:
     if: inputs.run-tests == true
-    runs-on: [self-hosted, arm64, '${{ inputs.environment }}']
+    # 'product' environment maps to the 'prod' runner label
+    runs-on: ${{ inputs.environment == 'product' && fromJSON('["self-hosted", "arm64", "prod"]') || fromJSON(format('["self-hosted", "arm64", "{0}"]', inputs.environment)) }}
     name: "Run Tests"
     steps:
       - run: |
@@ -89,7 +90,8 @@ jobs:
   build:
     environment: ${{ inputs.environment }}
     name: "Build & Push ECR Docker Image "
-    runs-on: [self-hosted, arm64, '${{ inputs.environment }}']
+    # 'product' environment maps to the 'prod' runner label
+    runs-on: ${{ inputs.environment == 'product' && fromJSON('["self-hosted", "arm64", "prod"]') || fromJSON(format('["self-hosted", "arm64", "{0}"]', inputs.environment)) }}
     env:
       HAVE_GLOBAL_PAT: ${{ secrets.GLOBAL_PAT != '' }}
       HAVE_RUN_CMD: ${{ inputs.run != '' }}


### PR DESCRIPTION
## Description

Follow-up to the frontend change (#79). The reusable golang and node build workflows build `runs-on` from `inputs.environment`, but there is no self-hosted runner labeled `product`. When callers pass `product`, the jobs can't be scheduled.

This maps the `product` environment input to the existing `prod` `arm64` runner label across the `tests` and `build`/`build-push-ecr` jobs in:

- `cached-golang-ecr-image-managed.yaml`
- `cached-node-ecr-image-managed.yaml`
- `node-ecr-image-managed.yaml`

```yaml
runs-on: ${{ inputs.environment == 'product' && fromJSON('["self-hosted", "arm64", "prod"]') || fromJSON(format('["self-hosted", "arm64", "{0}"]', inputs.environment)) }}
```

All other environment values (`dev`, `stag`, etc.) are unchanged. Only runner scheduling is affected; the `environment:` key, AWS role, and Slack messages still use the raw `inputs.environment` value.

## Change type

- Bug fix

## Jira

INFL-18366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test and build workflows to use the correct production runner for the `product` environment.
  * Preserved environment-specific runner selection for all other environments.
  * Applied the updated runner selection across cached and standard image workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->